### PR TITLE
Shell script showing what happens when the exit status code is reduce…

### DIFF
--- a/ExitStatus2
+++ b/ExitStatus2
@@ -1,0 +1,9 @@
+#/bin/bash
+#Testing the exist status again
+
+var1=10
+var2=30
+var3=$[$var1 * $var2]
+echo The value is $var3 
+exit $var3
+


### PR DESCRIPTION
…d to fit in the 0 to 255 range. The shll does tihs by using "modulo" arithmetic. The modulo of a value is the remainder after a division. The resulting number is the remainder of the specified number divided by 256. In the case of 300 the result value, the remainer is 44, which is what appears as the exit status code.